### PR TITLE
Adding support for Ubuntu 16.04 and CentOS 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Should the service be enabled on boot? (default: true)
 Name of the service (default: crucible)
 #### `install_java`
 Should the module install Java? (default: true)
+#### `java_home`
+Should crucible use a specified JAVA_HOME? (default: undef)
+#### `java_opts`
+Which Java VM arguments should be set when running crucible? (default: undef)
 #### `install_dir`
 Where should crucible be installed? (default: '/opt/crucible')
 #### `home_dir`
@@ -101,8 +105,8 @@ Specify alternate download URL (default: 'https://www.atlassian.com/software/cru
 ## Limitations
 
 ### OSes Supported:
-* RHEL/CentOS 6
-* Ubuntu 12.04, 14.04
+* RHEL/CentOS 6, 7
+* Ubuntu 12.04, 14.04, 16.04
 
 ### Dependencies:
 * puppetlabs-stdlib >= 3.0.0
@@ -110,7 +114,7 @@ Specify alternate download URL (default: 'https://www.atlassian.com/software/cru
 * puppetlabs-apt >= 1.4.0 (Only required for Ubuntu)
 
 
-This module has only been tested on CentOS6, Ubuntu 12.04, and Ubuntu 14.04 using OpenJRE8 on Puppet Enterprise 2015.3
+This module has only been tested on CentOS6, CentOS8, Ubuntu 12.04, Ubuntu 14.04 and Ubuntu 16.04 using OpenJRE8 on Puppet Enterprise 2015.3
 
 ## Development
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,6 +6,8 @@ class crucible (
   $service_name = 'crucible',
   $service_user = 'crucible',
   $install_java = true,
+  $java_home = undef,
+  $java_opts = undef,
   $install_dir = '/opt/crucible',
   $home_dir = undef,
   $fisheye_inst = '/opt/crucible-data',

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,10 +2,59 @@ class crucible::service inherits crucible {
 
   if $crucible::service_manage == true {
 
-    file { '/etc/init.d/crucible':
-      ensure  => file,
-      content => template('crucible/crucible-init.sh.erb'),
-      mode    => '0755',
+    # Determine the service provider to use
+    case $::osfamily {
+      'Debian' : {
+        case $::operatingsystem {
+          'Ubuntu' : {
+            if (versioncmp($::operatingsystemrelease, '15.04') >= 0) {
+              $service_provider = 'systemd'
+            } else {
+              $service_provider = 'upstart'
+            }
+          }
+          default: {
+            if (versioncmp($::operatingsystemmajrelease, '8') >= 0) {
+              $service_provider = 'systemd'
+            } else {
+              $service_provider = 'upstart'
+            }
+          }
+        }
+      }
+      'RedHat' : {
+        if (versioncmp($::operatingsystemmajrelease, '7') >= 0) {
+          $service_provider = 'systemd'
+        } else {
+          $service_provider = 'upstart'
+        }
+      }
+      default: {
+        $service_provider = 'upstart'
+      }
+    }
+
+    # Configure service
+    if ($service_provider == 'systemd') {
+      file { '/etc/systemd/system/crucible.service':
+        ensure  => present,
+        content => template('crucible/crucible.service.erb'),
+        mode    => '0644',
+      } ~>
+      exec { 'crucible-systemd-reload-before-service':
+        path        => ['/bin/', '/sbin/', '/usr/bin/', '/usr/sbin/'],
+        command     => 'systemctl daemon-reload > /dev/null',
+        notify      => Service['crucible'],
+        refreshonly => true,
+      }
+
+    } else {
+      file { '/etc/init.d/crucible':
+        ensure  => file,
+        content => template('crucible/crucible-init.sh.erb'),
+        mode    => '0755',
+        notify  => Service['crucible'],
+      }
     }
 
     service { 'crucible':
@@ -14,8 +63,6 @@ class crucible::service inherits crucible {
       name       => $crucible::service_name,
       hasstatus  => true,
       hasrestart => true,
-      require    => File['/etc/init.d/crucible'],
     }
   }
-
 }

--- a/templates/crucible-init.sh.erb
+++ b/templates/crucible-init.sh.erb
@@ -6,6 +6,15 @@
 # RUN_AS: The user to run fisheye as. Its recommended that you create a separate user account for security reasons
 RUN_AS=<%= @service_user %>
 
+<% if @java_home %>
+# JAVA_HOME: The path to Java installation
+JAVA_HOME="<%= @java_home %>"
+<% end %>
+<% if @java_opts %>
+# FISHEYE_OPTS: JVM options
+FISHEYE_OPTS="<%= @java_opts %>"
+<% end %>
+
 # FISHEYE_HOME: The path to the FishEye installation. Its recommended to create a symbolic link to the latest version so 
 # the process will still work after upgrades. 
 FISHEYE_HOME="<%= @install_dir %>"
@@ -15,7 +24,7 @@ FISHEYE_HOME="<%= @install_dir %>"
 FISHEYE_INST="<%= @fisheye_inst %>"
 fisheyectl() {
         if [ "x$USER" != "x$RUN_AS" ]; then 
-          su - "$RUN_AS" -c "FISHEYE_INST=$FISHEYE_INST $FISHEYE_HOME/bin/fisheyectl.sh $1"
+          su - "$RUN_AS" -c "FISHEYE_INST=$FISHEYE_INST <% if @java_home -%>JAVA_HOME=$JAVA_HOME<% end -%> <% if @java_opts -%>FISHEYE_OPTS=$FISHEYE_OPTS<% end -%> $FISHEYE_HOME/bin/fisheyectl.sh $1"
         else 
                 "$FISHEYE_HOME/bin/fisheyectl.sh" "$1"
         fi

--- a/templates/crucible.service.erb
+++ b/templates/crucible.service.erb
@@ -1,0 +1,26 @@
+[Unit]
+Description=Atlassian Fisheye + Crucible Server
+After=network.target
+
+[Service]
+Type=forking
+
+<% if @java_home -%>
+Environment='JAVA_HOME=<%= @java_home %>'
+<% end -%>
+<% if @java_opts -%>
+Environment='FISHEYE_OPTS=<%= @java_opts %>'
+<% end -%>
+Environment='FISHEYE_HOME=<%= @install_dir %>'
+Environment='FISHEYE_INST=<%= @fisheye_inst %>'
+
+ExecStart=<%= @install_dir %>/bin/fisheyectl.sh start
+ExecStop=<%= @install_dir %>/bin/fisheyectl.sh stop
+
+User=<%= @service_user %>
+UMask=0007
+RestartSec=10
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Adding support for Ubuntu 16.04 and CentOS 7 using systemd to manage the service configuration.
Allow using a custom Java home and specify VM arguments for service configuration.

This is a backwards compatible change considering the OSes that the module used to support. For newer OSes, it will use systemd to manage the service.